### PR TITLE
Update lint-test.yml

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -10,13 +10,16 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v5
-      with:
-        python-version: '3.10.12'
+      with: 
+        python-version: ${{ matrix.python-version }}
 
     - name: Cache Poetry install
       uses: actions/cache@v3


### PR DESCRIPTION
Makes tests run with Python versions 3.10-3.12