### PR TITLE
added hoverover text for graph

### DIFF
--- a/civiclens/templates/document.html
+++ b/civiclens/templates/document.html
@@ -183,7 +183,7 @@
 
           </p>
           <div class="row pt-2 pb-2" style="background-color: #FDFFF7; height: 250px;" id="chart"
-            title='{% for topic in nlp.topics %}The topic {{topic.topic|slice:":1"}} had {{topic.total}} total comments.{% endfor %}'>
+            title='{% for topic in nlp.topics %}{% for topic_0 in topic.topic|slice:":1" %}The topic {{topic_0}} had {{topic.total}} total comments.{% endfor %}{% endfor %}'>
             <div id="topics" style="display: none;">
               {{nlp.topics}}
             </div>


### PR DESCRIPTION
Very simple hover over to capture the total per topic cluster

<img width="824" alt="Screenshot 2024-05-22 at 11 14 09 AM" src="https://github.com/uchicago-capp-30320/CivicLens/assets/29237510/1c89c096-7b34-4b5f-944e-305d70f9971d">
